### PR TITLE
Update CoinManager.java for 1.9.4

### DIFF
--- a/src/com/darkblade12/itemslotmachine/coin/CoinManager.java
+++ b/src/com/darkblade12/itemslotmachine/coin/CoinManager.java
@@ -144,7 +144,7 @@ public final class CoinManager extends Manager {
 			Player p = event.getPlayer();
 			Sign s;
 			try {
-				s = (Sign) p.getTargetBlock(null, 6).getState();
+				s = (Sign) p.getTargetBlock((HashSet<Byte>) null, 6).getState();
 				if (!isShop(s))
 					return;
 			} catch (Exception e) {


### PR DESCRIPTION
s = (Sign) p.getTargetBlock(null, 6).getState();

does not work on 1.9.4
